### PR TITLE
Added safe delete for orders

### DIFF
--- a/web/pos/admin.py
+++ b/web/pos/admin.py
@@ -4,8 +4,10 @@ from django.contrib.admin import SimpleListFilter
 from django.db.models import F
 
 
-# Register your models here.
 admin.site.register(Cash)
+
+# Disable the "Delete" action and batch action
+admin.site.disable_action('delete_selected')
 
 # Admin settings
 admin.site.site_header = "EpPos Administration"
@@ -15,10 +17,6 @@ admin.site.site_title = "EpPos Administration"
 # Admin Models
 @admin.register(Setting)
 class SettingAdmin(admin.ModelAdmin):
-
-    # Deleting a setting is quite confusing
-    def has_delete_permission(self, *args, **kwargs):
-        return False
 
     # List Display Page Configuration
     list_display = (
@@ -64,6 +62,9 @@ class ProductAdmin(admin.ModelAdmin):
     The Admin Configuration for the model Product.
     """
 
+    # Allow delete
+    actions = ['delete_selected']
+
     # List Page Display Configuration
     list_display = (
         'name',
@@ -91,11 +92,20 @@ class ProductAdmin(admin.ModelAdmin):
     )
 
 
+# Safe deletion of orders
+def safe_delete_order(modeladmin, request, queryset):
+    queryset.filter(done=True).delete()
+safe_delete_order.short_description = "Delete completed orders"
+
+
 @admin.register(Order)
 class OrderAdmin(admin.ModelAdmin):
     """"
     Admin Site Configuration for Order Model
     """
+
+    # Add custom delete-if-not-done action
+    actions = [safe_delete_order]
 
     # List page display configuration
     list_display = (

--- a/web/pos/admin.py
+++ b/web/pos/admin.py
@@ -95,7 +95,7 @@ class ProductAdmin(admin.ModelAdmin):
 # Safe deletion of orders
 def safe_delete_order(modeladmin, request, queryset):
     queryset.filter(done=True).delete()
-safe_delete_order.short_description = "Delete completed orders"
+safe_delete_order.short_description = "Delete completed orders" #NOQA
 
 
 @admin.register(Order)

--- a/web/pos/admin.py
+++ b/web/pos/admin.py
@@ -95,7 +95,7 @@ class ProductAdmin(admin.ModelAdmin):
 # Safe deletion of orders
 def safe_delete_order(modeladmin, request, queryset):
     queryset.filter(done=True).delete()
-safe_delete_order.short_description = "Delete completed orders" #NOQA
+safe_delete_order.short_description = "Delete completed orders"  # NOQA
 
 
 @admin.register(Order)

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.11.2
-gunicorn==19.7.1
-Pillow==4.3.0
+Django>=2.0
+gunicorn>=19.0.0
+Pillow>=4.0.0


### PR DESCRIPTION
Orders now don't have the `delete` action, (you can still delete them individually) but they do have an action to delete them *if they are completed*. This is quite a bit safer