### PR TITLE
Fix old django on docker

### DIFF
--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,3 +1,3 @@
-Django==1.11.2
-gunicorn==19.7.1
-Pillow==4.3.0
+Django>=2.0
+gunicorn>=19.0.0
+Pillow>=4.3.0


### PR DESCRIPTION
Apparently docker was still using an old Django version. With a security issue. Oops