### PR TITLE
Deprecate manage.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+up: build
+	docker-compose up -d
+
+build:
+	mkdir -p web/db
+	docker-compose build
+	
+setup: build up
+	docker-compose exec web ./manage.py createsuperuser
+
+stop:
+	docker-compose down
+	docker-compose stop
+
+clean: stop
+	docker-compose rm
+
+rebuild: clean build up

--- a/manage.sh
+++ b/manage.sh
@@ -1,15 +1,23 @@
 #!/bin/bash
 
+function warn() {
+    echo "WARNING: This script is deprecated!"
+    echo "Please use the Makefile instead"
+}
+
 function up() {
+    warn()
     docker-compose up -d
 }
 
 function setup() {
+    warn()
 	mkdir -p web/db
     docker-compose up -d --build && docker-compose exec web ./manage.py createsuperuser
 }
 
 function stop() {
+    warn()
     docker-compose stop
 }
 


### PR DESCRIPTION
From this PR onwards, `manage.sh` will be deprecated in favour of a `Makefile`.
This to improve cross-platform compatibility (e.g. Windows).

I'm leaving this here for a little while, in case anyone wants to comment.