### PR TITLE
Fix cash payment and double requirement

### DIFF
--- a/web/pos/templates/pos/order.html
+++ b/web/pos/templates/pos/order.html
@@ -228,7 +228,7 @@
                             </form>
                         </div>
                         <div class="modal-footer">
-                            <button type="button" class="btn btn-primary" @click="payed('cash');" data-dismiss="modal" :disabled="cashgot < order.total_price">Submit</button>
+                            <button type="button" class="btn btn-primary" @click="payed('cash');" data-dismiss="modal" :disabled="cashgot <= order.total_price">Submit</button>
                         </div>
                     </div>
                 </div>

--- a/web/requirements.txt
+++ b/web/requirements.txt
@@ -1,5 +1,4 @@
 Django~=2.1
 gunicorn~=19.5.0
-gunicorn>=19.5.0
 Pillow~=4.3.0
 djangorestframework~=3.9.4


### PR DESCRIPTION
When a user is trying to install the software, there is a double requirement for gunicorn in the requirements.txt file which causes docker-compose to fail, and I fixed that.

Also when a user is trying to pay with cash the submit button would be disabled unless the person pays more money and needs change, so if they pay in exact change it wouldn't work but I fixed that.